### PR TITLE
fix: Store vectors in Qdrant for building ground truth

### DIFF
--- a/generators/dbpedia_openai_1M/generate_dbpedia_openai_1M.py
+++ b/generators/dbpedia_openai_1M/generate_dbpedia_openai_1M.py
@@ -25,9 +25,9 @@ def main():
 
 
     print("Shape of embeddings to be stored in db", index_embeddings.shape)
-    print(f"Number of embeddings from remaining embeddings ({other_embeddings.shape}) to be used for querying:", n)
+    print(f"Number of embeddings from remaining embeddings ({other_embeddings.shape}) to be used for querying:", N)
 
-    index_qdrant(index_embeddings, [])
+    index_qdrant(index_embeddings, None)
 
     path = os.path.join(DATA_DIR, "dbpedia_openai", "1M")
     Path(path).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Store vectors in Qdrant for building ground truth. Before this, 0 vectors were getting stored. The `payload` param expects either `None` or a list of the same size as the number of embeddings. Making it an empty list causes vectors to never even be stored. That's why `cloest_ids` were empty in `test.jsonl`